### PR TITLE
docs: Specify ghcr for docker user

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ docker run -p 8080:8080 \
   -e OPENAI_BASE_URL_INTERNAL=http://your-llm-api:8000 \
   -e OPENAI_BASE_URL=http://localhost:8080 \
   -e OPENAI_API_KEY=your-api-key \
-  open-responses-server
+  ghcr.io/teabranch/open-responses-server:latest
 ```
 
 Works great with docker-compose.yaml for Codex + your own model.


### PR DESCRIPTION
I think specifying registry is more convenient for docker user.